### PR TITLE
Alternative algorithm for setting the group ID in connected polygons

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -63,20 +63,36 @@ class Builder {
     return this._buildPolygonsFromGeometry(geometry);
   }
 
+  /**
+   * Spreads the group ID of the given polygon to all connected polygons
+   * @param {Object} polygon 
+   */
+  static _spreadGroupId (polygon) {
+    // Initialize the list of polygons to process with the seed polygon
+    var polygonsToProcess = new Set();
+    polygonsToProcess.add(polygon);
+    while(polygonsToProcess.size > 0) {
+      // Copy the nodes that will be processed in this iteration
+      const connectedPolygons = polygonsToProcess
+      polygonsToProcess = new Set();
+      connectedPolygons.forEach(connectedPolygon => {
+        // Add the polygon to the group
+        connectedPolygon.group = polygon.group;
+        // Add any unset neighbours to the list for processing in the next iteration
+        connectedPolygon.neighbours.forEach(neighbour => { 
+          if(neighbour.group == undefined) {
+            polygonsToProcess.add(neighbour);
+          }
+        });
+      });
+    }
+  }
+
   static _buildPolygonGroups (navigationMesh) {
 
     const polygons = navigationMesh.polygons;
 
     const polygonGroups = [];
-
-    const spreadGroupId = function (polygon) {
-      polygon.neighbours.forEach((neighbour) => {
-        if (neighbour.group === undefined) {
-          neighbour.group = polygon.group;
-          spreadGroupId(neighbour);
-        }
-      });
-    };
 
     polygons.forEach((polygon) => {
       if (polygon.group !== undefined) {
@@ -85,7 +101,7 @@ class Builder {
       } else {
         // we need to make a new group and spread its ID to neighbors
         polygon.group = polygonGroups.length;
-        spreadGroupId(polygon);
+        this._spreadGroupId(polygon);
         polygonGroups.push([polygon]);
       }
     });


### PR DESCRIPTION
Polygon group IDs are propagated to connected polygons using a "flood fill" approach. The original algorithm uses recursion to follow the neighbours, but this can lead to a stack overflow for meshes with large numbers of polygons.

[This archive](https://github.com/MozillaReality/three-pathfinding/files/5708400/navtest.zip) contains two GLB files with non-trivial nav-meshes of approximately 5K and 70K triangles each. The files have been annotated with the _MOZ_hubs_components_ _nav-mesh_ component for use in Mozilla Hubs. If you upload them as a scene via the Custom GLB option you can see from the browser console that the 70K version crashes the nav-mesh processor:

```
Uncaught (in promise) RangeError: Maximum call stack size exceeded
    at n (three-pathfinding.module.js:1)
    at three-pathfinding.module.js:1
    at Set.forEach (<anonymous>)
    at n (three-pathfinding.module.js:1)
    at three-pathfinding.module.js:1
    ...
```

The new algorithm maintains a set of polygons that it adds to when it finds new neighbours and removes from once the polygon is processed. The algorithm starts by initialising the set with the seed polygon and ends when the set is empty.

There doesn't appear to be any impact on runtime, with the 5K triangle mesh taking 2ms for both algorithms on Chrome on MacOS. The 70K mesh takes about 20ms, which implies it will scale reasonably.

There are probably faster algorithms, but this one is simple to maintain and "fast enough".

**5K Nav Mesh**
<img width="100%" alt="5K Nav Mesh" src="https://user-images.githubusercontent.com/303516/102473319-3c1c1700-404f-11eb-951b-dc9ddf3cc3d2.png">

**70K Nav Mesh**
<img width="100%" alt="70K Nav Mesh" src="https://user-images.githubusercontent.com/303516/102473356-450ce880-404f-11eb-895d-328495289471.png">
